### PR TITLE
Remove hyper-font-ligatures plugin

### DIFF
--- a/symlinks/hyper.js.symlink
+++ b/symlinks/hyper.js.symlink
@@ -73,5 +73,5 @@ module.exports = {
 
   keymaps: {},
   localPlugins: [],
-  plugins: ['hyper-font-ligatures', 'hyper-search'],
+  plugins: ['hyper-search'],
 }


### PR DESCRIPTION
This plugin doesn't work with Hyper v3, and v3.1, the next release, will have built-in ligature support